### PR TITLE
DenyNSGSecurityRuleCreationIfSourceAddressPrefixAndDestinationAddressPrefixIsAny.json

### DIFF
--- a/AzurePolicy/Policy/Deny/DenyNSGSecurityRuleCreationIfSourceAddressPrefixAndDestinationAddressPrefixIsAny.json
+++ b/AzurePolicy/Policy/Deny/DenyNSGSecurityRuleCreationIfSourceAddressPrefixAndDestinationAddressPrefixIsAny.json
@@ -1,0 +1,87 @@
+{
+  "mode": "All",
+  "policyRule": {
+    "if": {
+      "anyOf": [
+        {
+          "allOf": [
+            {
+              "allOf": [
+                {
+                  "field": "type",
+                  "equals": "Microsoft.Network/networkSecurityGroups"
+                }
+              ]
+            },
+            {
+              "count": {
+                "field": "Microsoft.Network/networkSecurityGroups/securityRules[*]",
+                "where": {
+                  "allOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].sourceAddressPrefix",
+                          "in": [
+                            "*",
+                            "ANY"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "field": "Microsoft.Network/networkSecurityGroups/securityRules[*].destinationAddressPrefix",
+                      "in": [
+                        "*",
+                        "ANY"
+                      ]
+                    }
+                  ]
+                }
+              },
+              "greater": 0
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "allOf": [
+                {
+                  "field": "type",
+                  "equals": "Microsoft.Network/networkSecurityGroups/securityRules"
+                }
+              ]
+            },
+            {
+              "allOf": [
+                {
+                  "anyOf": [
+                    {
+                      "field": "Microsoft.Network/networkSecurityGroups/securityRules/sourceAddressPrefix",
+                      "in": [
+                        "*",
+                        "ANY"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "field": "Microsoft.Network/networkSecurityGroups/securityRules/destinationAddressPrefix",
+                  "in": [
+                    "*",
+                    "ANY"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "then": {
+      "effect": "deny"
+    }
+  },
+  "parameters": {}
+}

--- a/AzurePolicy/Policy/Deny/DenyNSGSecurityRuleCreationIfSourceAddressPrefixAndDestinationAddressPrefixIsAny.json
+++ b/AzurePolicy/Policy/Deny/DenyNSGSecurityRuleCreationIfSourceAddressPrefixAndDestinationAddressPrefixIsAny.json
@@ -1,3 +1,12 @@
+/*DISCLAIMER: The sample custom policies are not supported under any Microsoft standard support program or service. 
+This is intended to be used in non-production environment only. The sample scripts are provided AS IS without warranty of any kind.
+Microsoft further disclaims all implied warranties including, without limitation, any implied warranties of merchantability or of fitness for a particular purpose.
+The entire risk arising out of the use or performance of the sample scripts and documentation remains with you.
+In no event shall Microsoft, its authors, owners of this blog, or anyone else involved in the creation, production, or delivery of the scripts be liable for any damages
+whatsoever (including without limitation, damages for loss of business profits, business interruption, loss of business information, or other pecuniary loss) arising out
+of the use of or inability to use the sample scripts or documentation, even if Microsoft has been advised of the possibility of such damages.*/
+
+/*Description: Azure policy to deny NSG security rule creation if SourceAddressPrefix and DestinationAddressPrefix is Any.*/
 {
   "mode": "All",
   "policyRule": {


### PR DESCRIPTION
Azure policy to deny NSG security rule creation if SourceAddressPrefix and DestinationAddressPrefix is Any