### PR TITLE
Calculate MD5 value for a file

### DIFF
--- a/Storage/Dotnet/MD5Calculation
+++ b/Storage/Dotnet/MD5Calculation
@@ -1,0 +1,34 @@
+//DISCLAIMER
+
+//The sample scripts are not supported under any Microsoft standard support program or service.
+//The sample scripts are provided AS IS without warranty of any kind.Microsoft further disclaims all implied warranties including, without limitation, 
+//any implied warranties of merchantability or of fitness for a particular purpose.The entire risk arising out of the use or performance of the sample 
+//scripts and documentation remains with you. In no event shall Microsoft, its authors, or anyone else involved in the creation, production, or delivery of 
+//the scripts be liable for any damages whatsoever (including without limitation, damages for loss of business profits, business interruption, loss of business 
+//information, or other pecuniary loss) arising out of the use of or inability to use the sample scripts or documentation, even if Microsoft has been advised of
+//the possibility of such damages.
+
+
+/*
+Demonstrate how to calculate MD5 locally
+This can be helpful to either verify that portal had the same MD% value as to ensure to tampering of the contents
+
+Also is very helpful when you are having a large file which get's uploaded using PutBlock & PutBlockList combination. 
+The Azure Portal doesn't calculate by-default the MD5 hash value for files uploaded using PutBlock & PutBlockList combination
+*/
+
+using System.Security.Cryptography;
+
+System.Text.ASCIIEncoding encoding = new System.Text.ASCIIEncoding();
+MD5 md5 = new MD5CryptoServiceProvider();
+
+byte[] messageBytesblob = System.IO.File.ReadAllBytes(@"C:\Thakur\LocalTest\file1.txt");
+byte[] hashmessageblob = md5.ComputeHash(messageBytesblob);
+
+////the below is how most open-source web shows as output
+string base64encodedhash = Convert.ToBase64String(hashmessageblob);
+Console.WriteLine(base64encodedhash);
+
+//the below is how the Azure Portal stores
+string hexmd5 = Convert.ToHexString(hashmessageblob);
+Console.WriteLine(hexmd5);


### PR DESCRIPTION
Demonstrate how to calculate MD5 locally
This can be helpful to either verify that portal had the same MD% value as to ensure to tampering of the contents

Also is very helpful when you are having a large file which get's uploaded using PutBlock & PutBlockList combination.  The Azure Portal doesn't calculate by-default the MD5 hash value for files uploaded using PutBlock & PutBlockList combination