### PR TITLE
Create Deny_Service_Bus_Private_Endpoint_creation_if_created_outside_of_current_subscription.json

### DIFF
--- a/AzurePolicy/Policy/Deny/Deny Service Bus Private Endpoint creation if created outside of current subscription/Deny_Service_Bus_Private_Endpoint_creation_if_created_outside_of_current_subscription.json
+++ b/AzurePolicy/Policy/Deny/Deny Service Bus Private Endpoint creation if created outside of current subscription/Deny_Service_Bus_Private_Endpoint_creation_if_created_outside_of_current_subscription.json
@@ -1,0 +1,52 @@
+/*DISCLAIMER: The sample custom policies are not supported under any Microsoft standard support program or service. 
+This is intended to be used in non-production environment only. The sample scripts are provided AS IS without warranty of any kind.
+Microsoft further disclaims all implied warranties including, without limitation, any implied warranties of merchantability or of fitness for a particular purpose.
+The entire risk arising out of the use or performance of the sample scripts and documentation remains with you.
+In no event shall Microsoft, its authors, owners of this blog, or anyone else involved in the creation, production, or delivery of the scripts be liable for any damages
+whatsoever (including without limitation, damages for loss of business profits, business interruption, loss of business information, or other pecuniary loss) arising out
+of the use of or inability to use the sample scripts or documentation, even if Microsoft has been advised of the possibility of such damages.*/
+
+/*Description: Azure policy to deny Service Bus Private Endpoint creation if created outside of current subscription*/
+
+{
+  "mode": "All",
+  "policyRule": {
+    "if": {
+      "allOf": [
+        {
+          "field": "type",
+          "equals": "Microsoft.Network/privateEndpoints"
+        },
+        {
+          "field": "Microsoft.Network/privateEndpoints/privateLinkServiceConnections[*].privateLinkServiceId",
+          "contains": "Microsoft.ServiceBus/namespaces"
+        },
+        {
+          "not":
+          {
+          "value": "[split(concat(field('Microsoft.Network/privateEndpoints/subnet.id'), '//'), '/')[2]]",
+          "equals": "[subscription().subscriptionId]"
+        }
+        }
+      ]
+    },
+    "then": {
+      "effect": "[parameters('effect')]"
+    }
+  },
+  "parameters": {
+    "effect": {
+      "type": "String",
+      "metadata": {
+        "displayName": "Effect",
+        "description": "Effect if the policy condition is verified"
+      },
+      "allowedValues": [
+        "Audit",
+        "Deny",
+        "Disabled"
+      ],
+      "defaultValue": "Deny"
+    }
+  }
+}


### PR DESCRIPTION
Pushed one custom policy to Deny Service Bus Private Endpoint creation if created outside of current subscription